### PR TITLE
feat: Miró-inspired type playground MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,244 @@
-import { useState } from 'react'
+import { useMemo, useRef, useState } from 'react'
+
+type Preset = 'readable' | 'poetic' | 'wild'
+
+type Settings = {
+  abstractness: number
+  lineWobble: number
+  symbolDensity: number
+  colorIntensity: number
+}
+
+type Point = { x: number; y: number }
+
+const CANVAS = { width: 900, height: 1200 }
+const MAX_TEXT_LENGTH = 24
+const DEFAULT_TEXT = 'LOVE'
+
+const PRESETS: Record<Preset, Settings> = {
+  readable: { abstractness: 20, lineWobble: 30, symbolDensity: 20, colorIntensity: 40 },
+  poetic: { abstractness: 50, lineWobble: 60, symbolDensity: 50, colorIntensity: 65 },
+  wild: { abstractness: 80, lineWobble: 85, symbolDensity: 80, colorIntensity: 90 },
+}
+
+const palette = {
+  paper: '#F5EEDC',
+  ink: '#111111',
+  red: '#E3342F',
+  yellow: '#F7C948',
+  blue: '#1E5EFF',
+  green: '#2FA84F',
+}
+
+function hashSeed(input: string) {
+  let h = 2166136261
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
+
+function createRand(seed: number) {
+  let value = seed || 1
+  return () => {
+    value = (value * 1664525 + 1013904223) >>> 0
+    return value / 0xffffffff
+  }
+}
+
+function jitter(point: Point, amount: number, rand: () => number): Point {
+  return {
+    x: point.x + (rand() - 0.5) * amount,
+    y: point.y + (rand() - 0.5) * amount,
+  }
+}
+
+function glyphPath(char: string): string {
+  const c = char.toUpperCase()
+  if (c === 'O' || c === '0') return 'M50,10 C75,10 90,25 90,50 C90,75 75,90 50,90 C25,90 10,75 10,50 C10,25 25,10 50,10 Z'
+  if (c === 'L') return 'M20,10 L20,90 L80,90'
+  if (c === 'V') return 'M10,10 L50,90 L90,10'
+  if (c === 'E') return 'M80,10 L20,10 L20,90 L80,90 M20,50 L65,50'
+  if (c === 'A') return 'M10,90 L50,10 L90,90 M30,58 L70,58'
+  if (c === 'I') return 'M50,10 L50,90'
+  if (c === ' ') return ''
+  return 'M20,10 L80,10 L80,90 L20,90 Z'
+}
 
 function App() {
-  const [message] = useState('纸牌玩法代码已清空，准备接入新功能。')
+  const [text, setText] = useState(DEFAULT_TEXT)
+  const [preset, setPreset] = useState<Preset>('poetic')
+  const [seed, setSeed] = useState(Date.now())
+  const [settings, setSettings] = useState<Settings>(PRESETS.poetic)
+  const svgRef = useRef<SVGSVGElement | null>(null)
+
+  const composition = useMemo(() => {
+    const rand = createRand(hashSeed(`${text}-${seed}`))
+    const chars = text.slice(0, MAX_TEXT_LENGTH).split('')
+    const wobble = (settings.lineWobble / 100) * 10
+    const abstractShift = (settings.abstractness / 100) * 24
+    const saturation = Math.max(35, settings.colorIntensity)
+
+    const lines: { path: string; color: string; width: number }[] = []
+    const symbols: { shape: 'dot' | 'star' | 'moon' | 'eye'; x: number; y: number; size: number; color: string }[] = []
+    const blobs: { cx: number; cy: number; rx: number; ry: number; color: string; opacity: number }[] = []
+
+    const columns = Math.min(chars.length, 7)
+    const charBox = (CANVAS.width - 180) / Math.max(columns, 1)
+
+    chars.forEach((char, idx) => {
+      const basePath = glyphPath(char)
+      if (!basePath) return
+      const col = idx % columns
+      const row = Math.floor(idx / columns)
+      const gx = 90 + col * charBox + (rand() - 0.5) * abstractShift
+      const gy = 200 + row * 210 + (rand() - 0.5) * abstractShift
+      const scale = 1.5 + rand() * 0.25
+
+      const pts = [
+        jitter({ x: gx + 20 * scale, y: gy + 20 * scale }, wobble, rand),
+        jitter({ x: gx + 90 * scale, y: gy + 20 * scale }, wobble, rand),
+        jitter({ x: gx + 90 * scale, y: gy + 130 * scale }, wobble, rand),
+        jitter({ x: gx + 20 * scale, y: gy + 130 * scale }, wobble, rand),
+      ]
+      lines.push({
+        path: `M${pts[0].x},${pts[0].y} L${pts[1].x},${pts[1].y} L${pts[2].x},${pts[2].y} L${pts[3].x},${pts[3].y} Z`,
+        color: palette.ink,
+        width: 3,
+      })
+
+      lines.push({
+        path: basePath.replace(/(\d+),(\d+)/g, (_, x, y) => `${gx + Number(x) * scale + (rand() - 0.5) * wobble},${gy + Number(y) * scale + (rand() - 0.5) * wobble}`),
+        color: palette.ink,
+        width: 4,
+      })
+
+      const localSymbols = Math.floor(1 + (settings.symbolDensity / 100) * 4)
+      for (let s = 0; s < localSymbols; s += 1) {
+        symbols.push({
+          shape: (['dot', 'star', 'moon', 'eye'] as const)[Math.floor(rand() * 4)],
+          x: gx + 80 + (rand() - 0.5) * 180,
+          y: gy + 80 + (rand() - 0.5) * 180,
+          size: 8 + rand() * 28,
+          color: [palette.red, palette.yellow, palette.blue, palette.green][Math.floor(rand() * 4)],
+        })
+      }
+
+      if (rand() > 0.35) {
+        blobs.push({
+          cx: gx + 70 + (rand() - 0.5) * 150,
+          cy: gy + 70 + (rand() - 0.5) * 150,
+          rx: 24 + rand() * 70,
+          ry: 18 + rand() * 40,
+          color: [palette.red, palette.yellow, palette.blue][Math.floor(rand() * 3)],
+          opacity: 0.15 + saturation / 250,
+        })
+      }
+    })
+
+    return { lines, symbols, blobs }
+  }, [text, seed, settings])
+
+  const applyPreset = (next: Preset) => {
+    setPreset(next)
+    setSettings(PRESETS[next])
+  }
+
+  const exportSvg = () => {
+    if (!svgRef.current) return
+    const serializer = new XMLSerializer()
+    const svgText = serializer.serializeToString(svgRef.current)
+    const blob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'miro-type-poster.svg'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  const exportPng = async () => {
+    if (!svgRef.current) return
+    const serializer = new XMLSerializer()
+    const svgText = serializer.serializeToString(svgRef.current)
+    const blob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob)
+    const img = new Image()
+    img.onload = () => {
+      const canvas = document.createElement('canvas')
+      canvas.width = CANVAS.width
+      canvas.height = CANVAS.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
+      ctx.drawImage(img, 0, 0)
+      const png = canvas.toDataURL('image/png')
+      const a = document.createElement('a')
+      a.href = png
+      a.download = 'miro-type-poster.png'
+      a.click()
+      URL.revokeObjectURL(url)
+    }
+    img.src = url
+  }
 
   return (
-    <main className="game">
-      <header className="panel">
-        <h1>Typing Master</h1>
-        <p>{message}</p>
-      </header>
+    <main className="app">
+      <section className="panel intro">
+        <h1>Miró Type Playground</h1>
+        <p>A playful experimental type system inspired by symbolic abstraction, hand-drawn lines, and poetic rhythm.</p>
+      </section>
+      <section className="workspace">
+        <aside className="panel controls">
+          <label>Text</label>
+          <input value={text} maxLength={MAX_TEXT_LENGTH} placeholder="Type a word or short phrase" onChange={(e) => setText(e.target.value)} />
+
+          <label>Preset</label>
+          <div className="preset-row">
+            {(['readable', 'poetic', 'wild'] as const).map((item) => (
+              <button key={item} className={preset === item ? 'active' : ''} onClick={() => applyPreset(item)}>{item}</button>
+            ))}
+          </div>
+
+          {([
+            ['Abstractness', 'abstractness'],
+            ['Line Wobble', 'lineWobble'],
+            ['Symbol Density', 'symbolDensity'],
+            ['Color Intensity', 'colorIntensity'],
+          ] as const).map(([label, key]) => (
+            <div key={key} className="slider-group">
+              <div><span>{label}</span><strong>{settings[key]}</strong></div>
+              <input type="range" min={0} max={100} value={settings[key]} onChange={(e) => setSettings((prev) => ({ ...prev, [key]: Number(e.target.value) }))} />
+            </div>
+          ))}
+
+          <div className="action-row">
+            <button onClick={() => setSeed(Date.now())}>Regenerate</button>
+            <button onClick={exportPng}>Export PNG</button>
+            <button onClick={exportSvg}>Export SVG</button>
+          </div>
+        </aside>
+
+        <section className="panel canvas-wrap">
+          <svg ref={svgRef} viewBox={`0 0 ${CANVAS.width} ${CANVAS.height}`}>
+            <rect width="100%" height="100%" fill={palette.paper} />
+            {composition.blobs.map((blob, i) => (
+              <ellipse key={`b-${i}`} cx={blob.cx} cy={blob.cy} rx={blob.rx} ry={blob.ry} fill={blob.color} opacity={blob.opacity} />
+            ))}
+            {composition.lines.map((line, i) => (
+              <path key={`l-${i}`} d={line.path} stroke={line.color} strokeWidth={line.width} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+            ))}
+            {composition.symbols.map((sym, i) => (
+              <g key={`s-${i}`} transform={`translate(${sym.x} ${sym.y})`}>
+                {sym.shape === 'dot' && <circle r={sym.size / 2} fill={sym.color} />}
+                {sym.shape === 'eye' && <ellipse rx={sym.size * 0.6} ry={sym.size * 0.36} fill="none" stroke={sym.color} strokeWidth={3} />}
+                {sym.shape === 'moon' && <path d={`M ${sym.size * 0.5} 0 A ${sym.size * 0.5} ${sym.size * 0.5} 0 1 1 ${-sym.size * 0.5} 0 A ${sym.size * 0.25} ${sym.size * 0.5} 0 1 0 ${sym.size * 0.5} 0`} fill={sym.color} />}
+                {sym.shape === 'star' && <path d={`M 0 ${-sym.size} L ${sym.size * 0.25} ${-sym.size * 0.25} L ${sym.size} 0 L ${sym.size * 0.25} ${sym.size * 0.25} L 0 ${sym.size} L ${-sym.size * 0.25} ${sym.size * 0.25} L ${-sym.size} 0 L ${-sym.size * 0.25} ${-sym.size * 0.25} Z`} fill="none" stroke={sym.color} strokeWidth={2.2} />}
+              </g>
+            ))}
+          </svg>
+        </section>
+      </section>
     </main>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,59 @@
 import { useMemo, useRef, useState } from 'react'
 
 type Page = 'home' | 'playground' | 'glyphs' | 'gallery' | 'about'
-type Preset = 'readable' | 'poetic' | 'wild'
-type Settings = { abstractness: number; lineWobble: number; symbolDensity: number; colorIntensity: number }
+type Preset = 'readable' | 'poetic' | 'wild' | 'custom'
+
+type Settings = {
+  abstractness: number
+  lineWobble: number
+  symbolDensity: number
+  colorIntensity: number
+}
 
 type SymbolShape = 'dot' | 'star' | 'moon' | 'eye'
+
 type Composition = {
   lines: { path: string; color: string; width: number }[]
   symbols: { shape: SymbolShape; x: number; y: number; size: number; color: string }[]
   blobs: { cx: number; cy: number; rx: number; ry: number; color: string; opacity: number }[]
 }
 
-const CANVAS = { width: 900, height: 1200 }
+const CANVAS = { width: 1200, height: 1600 }
 const MAX_TEXT_LENGTH = 24
 const DEFAULT_TEXT = 'LOVE'
+const ALLOWED_TEXT_REGEX = /[^A-Za-z0-9.,!?:;\-/\s]/g
 
-const PRESETS: Record<Preset, Settings> = {
+const PRESETS: Record<Exclude<Preset, 'custom'>, Settings> = {
   readable: { abstractness: 20, lineWobble: 30, symbolDensity: 20, colorIntensity: 40 },
   poetic: { abstractness: 50, lineWobble: 60, symbolDensity: 50, colorIntensity: 65 },
   wild: { abstractness: 80, lineWobble: 85, symbolDensity: 80, colorIntensity: 90 },
 }
 
-const GALLERY_CASES = ['LOVE', 'DREAM', 'PLAY', 'TYPE', 'FAR AWAY', 'NO HOME', 'LOW SKY', 'BLUE BIRD', 'FUTURE', 'POETIC CODE', 'SILENT SUN', 'FLOATING LINE']
+const PAGES: Page[] = ['home', 'playground', 'glyphs', 'gallery', 'about']
+const GALLERY_CASES = ['LOVE', 'DREAM', 'PLAY', 'TYPE', 'FAR AWAY', 'NO HOME', 'LOW SKY', 'BLUE BIRD', 'THE FUTURE', 'POETIC CODE', 'SILENT SUN', 'FLOATING LINE']
+const GLYPHS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?:;-/'.split('')
 const PALETTE = { paper: '#F5EEDC', ink: '#111111', red: '#E3342F', yellow: '#F7C948', blue: '#1E5EFF', green: '#2FA84F' }
 
-const glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?:;-/'.split('')
+function hashSeed(input: string) {
+  let h = 2166136261
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i)
+    h = Math.imul(h, 16777619)
+  }
+  return h >>> 0
+}
 
-function hashSeed(input: string) { let h = 2166136261; for (let i = 0; i < input.length; i += 1) { h ^= input.charCodeAt(i); h = Math.imul(h, 16777619) } return h >>> 0 }
-function createRand(seed: number) { let value = seed || 1; return () => { value = (value * 1664525 + 1013904223) >>> 0; return value / 0xffffffff } }
-function jitter(x: number, amount: number, rand: () => number) { return x + (rand() - 0.5) * amount }
+function createRand(seed: number) {
+  let value = seed || 1
+  return () => {
+    value = (value * 1664525 + 1013904223) >>> 0
+    return value / 0xffffffff
+  }
+}
+
+function jitter(x: number, amount: number, rand: () => number) {
+  return x + (rand() - 0.5) * amount
+}
 
 function glyphPath(char: string): string {
   const c = char.toUpperCase()
@@ -43,43 +68,59 @@ function glyphPath(char: string): string {
   return 'M20,10 L80,10 L80,90 L20,90 Z'
 }
 
+function sanitizeText(value: string) {
+  return value.replace(ALLOWED_TEXT_REGEX, '').slice(0, MAX_TEXT_LENGTH)
+}
+
 function generateComposition(text: string, seed: number, settings: Settings): Composition {
   const rand = createRand(hashSeed(`${text}-${seed}`))
-  const chars = text.slice(0, MAX_TEXT_LENGTH).split('')
-  const wobble = (settings.lineWobble / 100) * 10
-  const abstractShift = (settings.abstractness / 100) * 24
+  const chars = sanitizeText(text || DEFAULT_TEXT).split('')
+  const wobble = (settings.lineWobble / 100) * 12
+  const abstractShift = (settings.abstractness / 100) * 36
   const saturation = Math.max(35, settings.colorIntensity)
+
   const lines: Composition['lines'] = []
   const symbols: Composition['symbols'] = []
   const blobs: Composition['blobs'] = []
+
   const columns = Math.min(Math.max(chars.length, 1), 7)
-  const charBox = (CANVAS.width - 180) / columns
+  const charBox = (CANVAS.width - 220) / columns
 
   chars.forEach((char, idx) => {
     const basePath = glyphPath(char)
     if (!basePath) return
-    const gx = 90 + (idx % columns) * charBox + (rand() - 0.5) * abstractShift
-    const gy = 200 + Math.floor(idx / columns) * 210 + (rand() - 0.5) * abstractShift
-    const scale = 1.5 + rand() * 0.25
+
+    const gx = 110 + (idx % columns) * charBox + (rand() - 0.5) * abstractShift
+    const gy = 240 + Math.floor(idx / columns) * 260 + (rand() - 0.5) * abstractShift
+    const scale = 1.9 + rand() * 0.3
 
     lines.push({
       path: basePath.replace(/(\d+),(\d+)/g, (_, x, y) => `${jitter(gx + Number(x) * scale, wobble, rand)},${jitter(gy + Number(y) * scale, wobble, rand)}`),
       color: PALETTE.ink,
-      width: 4,
+      width: 5,
     })
 
     const localSymbols = Math.floor(1 + (settings.symbolDensity / 100) * 4)
     for (let s = 0; s < localSymbols; s += 1) {
       symbols.push({
         shape: (['dot', 'star', 'moon', 'eye'] as const)[Math.floor(rand() * 4)],
-        x: gx + 80 + (rand() - 0.5) * 180,
-        y: gy + 80 + (rand() - 0.5) * 180,
-        size: 8 + rand() * 28,
+        x: gx + 90 + (rand() - 0.5) * 200,
+        y: gy + 95 + (rand() - 0.5) * 210,
+        size: 10 + rand() * 34,
         color: [PALETTE.red, PALETTE.yellow, PALETTE.blue, PALETTE.green][Math.floor(rand() * 4)],
       })
     }
 
-    if (rand() > 0.35) blobs.push({ cx: gx + 70 + (rand() - 0.5) * 150, cy: gy + 70 + (rand() - 0.5) * 150, rx: 24 + rand() * 70, ry: 18 + rand() * 40, color: [PALETTE.red, PALETTE.yellow, PALETTE.blue][Math.floor(rand() * 3)], opacity: 0.15 + saturation / 250 })
+    if (rand() > 0.35) {
+      blobs.push({
+        cx: gx + 90 + (rand() - 0.5) * 180,
+        cy: gy + 100 + (rand() - 0.5) * 180,
+        rx: 28 + rand() * 80,
+        ry: 20 + rand() * 56,
+        color: [PALETTE.red, PALETTE.yellow, PALETTE.blue][Math.floor(rand() * 3)],
+        opacity: 0.16 + saturation / 250,
+      })
+    }
   })
 
   return { lines, symbols, blobs }
@@ -92,26 +133,53 @@ export default function App() {
   const [settings, setSettings] = useState<Settings>(PRESETS.poetic)
   const [seed, setSeed] = useState(Date.now())
   const svgRef = useRef<SVGSVGElement | null>(null)
+
   const composition = useMemo(() => generateComposition(text, seed, settings), [text, seed, settings])
 
-  const applyPreset = (next: Preset) => { setPreset(next); setSettings(PRESETS[next]) }
-  const goPlayground = (sample?: string) => { if (sample) setText(sample); setPage('playground'); setSeed(Date.now()) }
+  const applyPreset = (next: Exclude<Preset, 'custom'>) => {
+    setPreset(next)
+    setSettings(PRESETS[next])
+  }
+
+  const updateSetting = (key: keyof Settings, value: number) => {
+    setPreset('custom')
+    setSettings((prev) => ({ ...prev, [key]: value }))
+  }
+
+  const goPlayground = (sample?: string) => {
+    if (sample) setText(sample)
+    setPage('playground')
+    setSeed(Date.now())
+  }
 
   const exportSvg = () => {
     if (!svgRef.current) return
     const blob = new Blob([new XMLSerializer().serializeToString(svgRef.current)], { type: 'image/svg+xml;charset=utf-8' })
-    const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'miro-type-poster.svg'; a.click(); URL.revokeObjectURL(url)
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'miro-type-poster.svg'
+    a.click()
+    URL.revokeObjectURL(url)
   }
 
   const exportPng = () => {
     if (!svgRef.current) return
     const svgBlob = new Blob([new XMLSerializer().serializeToString(svgRef.current)], { type: 'image/svg+xml;charset=utf-8' })
-    const url = URL.createObjectURL(svgBlob); const img = new Image()
+    const url = URL.createObjectURL(svgBlob)
+    const img = new Image()
     img.onload = () => {
-      const canvas = document.createElement('canvas'); canvas.width = CANVAS.width; canvas.height = CANVAS.height
-      const ctx = canvas.getContext('2d'); if (!ctx) return
+      const canvas = document.createElement('canvas')
+      canvas.width = CANVAS.width
+      canvas.height = CANVAS.height
+      const ctx = canvas.getContext('2d')
+      if (!ctx) return
       ctx.drawImage(img, 0, 0)
-      const a = document.createElement('a'); a.href = canvas.toDataURL('image/png'); a.download = 'miro-type-poster.png'; a.click(); URL.revokeObjectURL(url)
+      const a = document.createElement('a')
+      a.href = canvas.toDataURL('image/png')
+      a.download = 'miro-type-poster.png'
+      a.click()
+      URL.revokeObjectURL(url)
     }
     img.src = url
   }
@@ -120,16 +188,136 @@ export default function App() {
     <main className="app">
       <header className="panel topbar">
         <h1>Miró Type Playground</h1>
-        <nav>{(['home', 'playground', 'glyphs', 'gallery', 'about'] as const).map((p) => <button key={p} className={page === p ? 'active' : ''} onClick={() => setPage(p)}>{p}</button>)}</nav>
+        <nav>
+          {PAGES.map((item) => (
+            <button key={item} className={page === item ? 'active' : ''} onClick={() => setPage(item)}>
+              {item}
+            </button>
+          ))}
+        </nav>
       </header>
 
-      {page === 'home' && <section className="panel page"><h2>A playful experimental type system</h2><p>Inspired by symbolic abstraction, hand-drawn lines, and poetic visual rhythm.</p><div className="action-row"><button onClick={() => goPlayground()}>Start Creating</button><button onClick={() => setPage('glyphs')}>Explore Glyphs</button></div></section>}
+      {page === 'home' && (
+        <section className="panel page">
+          <h2>A playful experimental type system</h2>
+          <p>Inspired by symbolic abstraction, hand-drawn lines, and poetic visual rhythm.</p>
+          <div className="action-row home-actions">
+            <button onClick={() => goPlayground()}>Start Creating</button>
+            <button onClick={() => setPage('glyphs')}>Explore Glyphs</button>
+          </div>
+        </section>
+      )}
 
-      {page === 'playground' && <section className="workspace"><aside className="panel controls"><label>Text</label><input value={text} maxLength={MAX_TEXT_LENGTH} placeholder="Type a word or short phrase" onChange={(e) => setText(e.target.value)} /><label>Preset</label><div className="preset-row">{(['readable', 'poetic', 'wild'] as const).map((item) => <button key={item} className={preset === item ? 'active' : ''} onClick={() => applyPreset(item)}>{item}</button>)}</div>{([['Abstractness', 'abstractness'], ['Line Wobble', 'lineWobble'], ['Symbol Density', 'symbolDensity'], ['Color Intensity', 'colorIntensity']] as const).map(([label, key]) => <div key={key} className="slider-group"><div><span>{label}</span><strong>{settings[key]}</strong></div><input type="range" min={0} max={100} value={settings[key]} onChange={(e) => setSettings((prev) => ({ ...prev, [key]: Number(e.target.value) }))} /></div>)}<div className="action-row"><button onClick={() => setSeed(Date.now())}>Regenerate</button><button onClick={exportPng}>Export PNG</button><button onClick={exportSvg}>Export SVG</button></div></aside><section className="panel canvas-wrap"><svg ref={svgRef} viewBox={`0 0 ${CANVAS.width} ${CANVAS.height}`}><rect width="100%" height="100%" fill={PALETTE.paper} />{composition.blobs.map((blob, i) => <ellipse key={i} cx={blob.cx} cy={blob.cy} rx={blob.rx} ry={blob.ry} fill={blob.color} opacity={blob.opacity} />)}{composition.lines.map((line, i) => <path key={i} d={line.path} stroke={line.color} strokeWidth={line.width} fill="none" strokeLinecap="round" strokeLinejoin="round" />)}{composition.symbols.map((sym, i) => <g key={i} transform={`translate(${sym.x} ${sym.y})`}>{sym.shape === 'dot' && <circle r={sym.size / 2} fill={sym.color} />}{sym.shape === 'eye' && <ellipse rx={sym.size * 0.6} ry={sym.size * 0.36} fill="none" stroke={sym.color} strokeWidth={3} />}{sym.shape === 'moon' && <path d={`M ${sym.size * 0.5} 0 A ${sym.size * 0.5} ${sym.size * 0.5} 0 1 1 ${-sym.size * 0.5} 0 A ${sym.size * 0.25} ${sym.size * 0.5} 0 1 0 ${sym.size * 0.5} 0`} fill={sym.color} />}{sym.shape === 'star' && <path d={`M 0 ${-sym.size} L ${sym.size * 0.25} ${-sym.size * 0.25} L ${sym.size} 0 L ${sym.size * 0.25} ${sym.size * 0.25} L 0 ${sym.size} L ${-sym.size * 0.25} ${sym.size * 0.25} L ${-sym.size} 0 L ${-sym.size * 0.25} ${-sym.size * 0.25} Z`} fill="none" stroke={sym.color} strokeWidth={2.2} />}</g>)}</svg></section></section>}
+      {page === 'playground' && (
+        <section className="workspace">
+          <aside className="panel controls">
+            <label htmlFor="text-input">Text</label>
+            <input
+              id="text-input"
+              value={text}
+              maxLength={MAX_TEXT_LENGTH}
+              placeholder="Type a word or short phrase"
+              onChange={(e) => setText(sanitizeText(e.target.value))}
+            />
+            <small>Supports: A-Z / a-z / 0-9 / . , ! ? : ; - / / 空格</small>
 
-      {page === 'glyphs' && <section className="panel page"><h2>Glyph System</h2><p>Base Skeleton → Miró Line → Symbolic Composition</p><div className="glyph-grid">{glyphs.map((g) => <div key={g} className="glyph-cell">{g}</div>)}</div></section>}
-      {page === 'gallery' && <section className="panel page"><h2>Gallery</h2><div className="gallery-grid">{GALLERY_CASES.map((item) => <button key={item} onClick={() => goPlayground(item)}>{item}</button>)}</div></section>}
-      {page === 'about' && <section className="panel page"><h2>About</h2><p>This project is not an official Joan Miró typeface. It is an experimental type playground inspired by symbolic abstraction, childlike marks, poetic space, and primary-color composition.</p><p>这不是 Joan Miró 官方字体，也不是对其具体作品的复制。它是一套受其视觉语言启发的实验字体系统。</p></section>}
+            <label>Preset ({preset})</label>
+            <div className="preset-row">
+              {(['readable', 'poetic', 'wild'] as const).map((item) => (
+                <button key={item} className={preset === item ? 'active' : ''} onClick={() => applyPreset(item)}>
+                  {item}
+                </button>
+              ))}
+            </div>
+
+            {(
+              [
+                ['Abstractness', 'abstractness'],
+                ['Line Wobble', 'lineWobble'],
+                ['Symbol Density', 'symbolDensity'],
+                ['Color Intensity', 'colorIntensity'],
+              ] as const
+            ).map(([label, key]) => (
+              <div key={key} className="slider-group">
+                <div>
+                  <span>{label}</span>
+                  <strong>{settings[key]}</strong>
+                </div>
+                <input type="range" min={0} max={100} value={settings[key]} onChange={(e) => updateSetting(key, Number(e.target.value))} />
+              </div>
+            ))}
+
+            <div className="action-row">
+              <button onClick={() => setSeed(Date.now())}>Regenerate</button>
+              <button onClick={exportPng}>Export PNG</button>
+              <button onClick={exportSvg}>Export SVG</button>
+            </div>
+          </aside>
+
+          <section className="panel canvas-wrap">
+            <svg ref={svgRef} viewBox={`0 0 ${CANVAS.width} ${CANVAS.height}`}>
+              <rect width="100%" height="100%" fill={PALETTE.paper} />
+              {composition.blobs.map((blob, i) => (
+                <ellipse key={`blob-${i}`} cx={blob.cx} cy={blob.cy} rx={blob.rx} ry={blob.ry} fill={blob.color} opacity={blob.opacity} />
+              ))}
+              {composition.lines.map((line, i) => (
+                <path key={`line-${i}`} d={line.path} stroke={line.color} strokeWidth={line.width} fill="none" strokeLinecap="round" strokeLinejoin="round" />
+              ))}
+              {composition.symbols.map((sym, i) => (
+                <g key={`symbol-${i}`} transform={`translate(${sym.x} ${sym.y})`}>
+                  {sym.shape === 'dot' && <circle r={sym.size / 2} fill={sym.color} />}
+                  {sym.shape === 'eye' && <ellipse rx={sym.size * 0.6} ry={sym.size * 0.36} fill="none" stroke={sym.color} strokeWidth={3} />}
+                  {sym.shape === 'moon' && (
+                    <path d={`M ${sym.size * 0.5} 0 A ${sym.size * 0.5} ${sym.size * 0.5} 0 1 1 ${-sym.size * 0.5} 0 A ${sym.size * 0.25} ${sym.size * 0.5} 0 1 0 ${sym.size * 0.5} 0`} fill={sym.color} />
+                  )}
+                  {sym.shape === 'star' && (
+                    <path d={`M 0 ${-sym.size} L ${sym.size * 0.25} ${-sym.size * 0.25} L ${sym.size} 0 L ${sym.size * 0.25} ${sym.size * 0.25} L 0 ${sym.size} L ${-sym.size * 0.25} ${sym.size * 0.25} L ${-sym.size} 0 L ${-sym.size * 0.25} ${-sym.size * 0.25} Z`} fill="none" stroke={sym.color} strokeWidth={2.2} />
+                  )}
+                </g>
+              ))}
+            </svg>
+          </section>
+        </section>
+      )}
+
+      {page === 'glyphs' && (
+        <section className="panel page">
+          <h2>Glyph System</h2>
+          <p>Base Skeleton → Miró Line → Symbolic Composition</p>
+          <div className="glyph-grid">
+            {GLYPHS.map((glyph) => (
+              <div key={glyph} className="glyph-cell">
+                {glyph}
+              </div>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {page === 'gallery' && (
+        <section className="panel page">
+          <h2>Gallery</h2>
+          <p>Click any sample to open it in Playground with a new generated composition.</p>
+          <div className="gallery-grid">
+            {GALLERY_CASES.map((item) => (
+              <button key={item} onClick={() => goPlayground(item)}>
+                {item}
+              </button>
+            ))}
+          </div>
+        </section>
+      )}
+
+      {page === 'about' && (
+        <section className="panel page">
+          <h2>About</h2>
+          <p>
+            This project is not an official Joan Miró typeface. It is an experimental type playground inspired by symbolic abstraction, childlike marks,
+            poetic space, and primary-color composition.
+          </p>
+          <p>这不是 Joan Miró 官方字体，也不是对其具体作品的复制。它是一套受其视觉语言启发的实验字体系统，尝试将手绘线条、原始符号、漂浮空间和高纯度色彩转译为可交互的字体生成规则。</p>
+        </section>
+      )}
     </main>
   )
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,15 +1,15 @@
 import { useMemo, useRef, useState } from 'react'
 
+type Page = 'home' | 'playground' | 'glyphs' | 'gallery' | 'about'
 type Preset = 'readable' | 'poetic' | 'wild'
+type Settings = { abstractness: number; lineWobble: number; symbolDensity: number; colorIntensity: number }
 
-type Settings = {
-  abstractness: number
-  lineWobble: number
-  symbolDensity: number
-  colorIntensity: number
+type SymbolShape = 'dot' | 'star' | 'moon' | 'eye'
+type Composition = {
+  lines: { path: string; color: string; width: number }[]
+  symbols: { shape: SymbolShape; x: number; y: number; size: number; color: string }[]
+  blobs: { cx: number; cy: number; rx: number; ry: number; color: string; opacity: number }[]
 }
-
-type Point = { x: number; y: number }
 
 const CANVAS = { width: 900, height: 1200 }
 const MAX_TEXT_LENGTH = 24
@@ -21,38 +21,14 @@ const PRESETS: Record<Preset, Settings> = {
   wild: { abstractness: 80, lineWobble: 85, symbolDensity: 80, colorIntensity: 90 },
 }
 
-const palette = {
-  paper: '#F5EEDC',
-  ink: '#111111',
-  red: '#E3342F',
-  yellow: '#F7C948',
-  blue: '#1E5EFF',
-  green: '#2FA84F',
-}
+const GALLERY_CASES = ['LOVE', 'DREAM', 'PLAY', 'TYPE', 'FAR AWAY', 'NO HOME', 'LOW SKY', 'BLUE BIRD', 'FUTURE', 'POETIC CODE', 'SILENT SUN', 'FLOATING LINE']
+const PALETTE = { paper: '#F5EEDC', ink: '#111111', red: '#E3342F', yellow: '#F7C948', blue: '#1E5EFF', green: '#2FA84F' }
 
-function hashSeed(input: string) {
-  let h = 2166136261
-  for (let i = 0; i < input.length; i += 1) {
-    h ^= input.charCodeAt(i)
-    h = Math.imul(h, 16777619)
-  }
-  return h >>> 0
-}
+const glyphs = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789.,!?:;-/'.split('')
 
-function createRand(seed: number) {
-  let value = seed || 1
-  return () => {
-    value = (value * 1664525 + 1013904223) >>> 0
-    return value / 0xffffffff
-  }
-}
-
-function jitter(point: Point, amount: number, rand: () => number): Point {
-  return {
-    x: point.x + (rand() - 0.5) * amount,
-    y: point.y + (rand() - 0.5) * amount,
-  }
-}
+function hashSeed(input: string) { let h = 2166136261; for (let i = 0; i < input.length; i += 1) { h ^= input.charCodeAt(i); h = Math.imul(h, 16777619) } return h >>> 0 }
+function createRand(seed: number) { let value = seed || 1; return () => { value = (value * 1664525 + 1013904223) >>> 0; return value / 0xffffffff } }
+function jitter(x: number, amount: number, rand: () => number) { return x + (rand() - 0.5) * amount }
 
 function glyphPath(char: string): string {
   const c = char.toUpperCase()
@@ -62,185 +38,98 @@ function glyphPath(char: string): string {
   if (c === 'E') return 'M80,10 L20,10 L20,90 L80,90 M20,50 L65,50'
   if (c === 'A') return 'M10,90 L50,10 L90,90 M30,58 L70,58'
   if (c === 'I') return 'M50,10 L50,90'
+  if (c === 'S') return 'M80,20 C55,0 20,20 40,45 C55,65 85,55 75,85 C55,100 30,90 20,70'
   if (c === ' ') return ''
   return 'M20,10 L80,10 L80,90 L20,90 Z'
 }
 
-function App() {
-  const [text, setText] = useState(DEFAULT_TEXT)
-  const [preset, setPreset] = useState<Preset>('poetic')
-  const [seed, setSeed] = useState(Date.now())
-  const [settings, setSettings] = useState<Settings>(PRESETS.poetic)
-  const svgRef = useRef<SVGSVGElement | null>(null)
+function generateComposition(text: string, seed: number, settings: Settings): Composition {
+  const rand = createRand(hashSeed(`${text}-${seed}`))
+  const chars = text.slice(0, MAX_TEXT_LENGTH).split('')
+  const wobble = (settings.lineWobble / 100) * 10
+  const abstractShift = (settings.abstractness / 100) * 24
+  const saturation = Math.max(35, settings.colorIntensity)
+  const lines: Composition['lines'] = []
+  const symbols: Composition['symbols'] = []
+  const blobs: Composition['blobs'] = []
+  const columns = Math.min(Math.max(chars.length, 1), 7)
+  const charBox = (CANVAS.width - 180) / columns
 
-  const composition = useMemo(() => {
-    const rand = createRand(hashSeed(`${text}-${seed}`))
-    const chars = text.slice(0, MAX_TEXT_LENGTH).split('')
-    const wobble = (settings.lineWobble / 100) * 10
-    const abstractShift = (settings.abstractness / 100) * 24
-    const saturation = Math.max(35, settings.colorIntensity)
+  chars.forEach((char, idx) => {
+    const basePath = glyphPath(char)
+    if (!basePath) return
+    const gx = 90 + (idx % columns) * charBox + (rand() - 0.5) * abstractShift
+    const gy = 200 + Math.floor(idx / columns) * 210 + (rand() - 0.5) * abstractShift
+    const scale = 1.5 + rand() * 0.25
 
-    const lines: { path: string; color: string; width: number }[] = []
-    const symbols: { shape: 'dot' | 'star' | 'moon' | 'eye'; x: number; y: number; size: number; color: string }[] = []
-    const blobs: { cx: number; cy: number; rx: number; ry: number; color: string; opacity: number }[] = []
-
-    const columns = Math.min(chars.length, 7)
-    const charBox = (CANVAS.width - 180) / Math.max(columns, 1)
-
-    chars.forEach((char, idx) => {
-      const basePath = glyphPath(char)
-      if (!basePath) return
-      const col = idx % columns
-      const row = Math.floor(idx / columns)
-      const gx = 90 + col * charBox + (rand() - 0.5) * abstractShift
-      const gy = 200 + row * 210 + (rand() - 0.5) * abstractShift
-      const scale = 1.5 + rand() * 0.25
-
-      const pts = [
-        jitter({ x: gx + 20 * scale, y: gy + 20 * scale }, wobble, rand),
-        jitter({ x: gx + 90 * scale, y: gy + 20 * scale }, wobble, rand),
-        jitter({ x: gx + 90 * scale, y: gy + 130 * scale }, wobble, rand),
-        jitter({ x: gx + 20 * scale, y: gy + 130 * scale }, wobble, rand),
-      ]
-      lines.push({
-        path: `M${pts[0].x},${pts[0].y} L${pts[1].x},${pts[1].y} L${pts[2].x},${pts[2].y} L${pts[3].x},${pts[3].y} Z`,
-        color: palette.ink,
-        width: 3,
-      })
-
-      lines.push({
-        path: basePath.replace(/(\d+),(\d+)/g, (_, x, y) => `${gx + Number(x) * scale + (rand() - 0.5) * wobble},${gy + Number(y) * scale + (rand() - 0.5) * wobble}`),
-        color: palette.ink,
-        width: 4,
-      })
-
-      const localSymbols = Math.floor(1 + (settings.symbolDensity / 100) * 4)
-      for (let s = 0; s < localSymbols; s += 1) {
-        symbols.push({
-          shape: (['dot', 'star', 'moon', 'eye'] as const)[Math.floor(rand() * 4)],
-          x: gx + 80 + (rand() - 0.5) * 180,
-          y: gy + 80 + (rand() - 0.5) * 180,
-          size: 8 + rand() * 28,
-          color: [palette.red, palette.yellow, palette.blue, palette.green][Math.floor(rand() * 4)],
-        })
-      }
-
-      if (rand() > 0.35) {
-        blobs.push({
-          cx: gx + 70 + (rand() - 0.5) * 150,
-          cy: gy + 70 + (rand() - 0.5) * 150,
-          rx: 24 + rand() * 70,
-          ry: 18 + rand() * 40,
-          color: [palette.red, palette.yellow, palette.blue][Math.floor(rand() * 3)],
-          opacity: 0.15 + saturation / 250,
-        })
-      }
+    lines.push({
+      path: basePath.replace(/(\d+),(\d+)/g, (_, x, y) => `${jitter(gx + Number(x) * scale, wobble, rand)},${jitter(gy + Number(y) * scale, wobble, rand)}`),
+      color: PALETTE.ink,
+      width: 4,
     })
 
-    return { lines, symbols, blobs }
-  }, [text, seed, settings])
+    const localSymbols = Math.floor(1 + (settings.symbolDensity / 100) * 4)
+    for (let s = 0; s < localSymbols; s += 1) {
+      symbols.push({
+        shape: (['dot', 'star', 'moon', 'eye'] as const)[Math.floor(rand() * 4)],
+        x: gx + 80 + (rand() - 0.5) * 180,
+        y: gy + 80 + (rand() - 0.5) * 180,
+        size: 8 + rand() * 28,
+        color: [PALETTE.red, PALETTE.yellow, PALETTE.blue, PALETTE.green][Math.floor(rand() * 4)],
+      })
+    }
 
-  const applyPreset = (next: Preset) => {
-    setPreset(next)
-    setSettings(PRESETS[next])
-  }
+    if (rand() > 0.35) blobs.push({ cx: gx + 70 + (rand() - 0.5) * 150, cy: gy + 70 + (rand() - 0.5) * 150, rx: 24 + rand() * 70, ry: 18 + rand() * 40, color: [PALETTE.red, PALETTE.yellow, PALETTE.blue][Math.floor(rand() * 3)], opacity: 0.15 + saturation / 250 })
+  })
+
+  return { lines, symbols, blobs }
+}
+
+export default function App() {
+  const [page, setPage] = useState<Page>('home')
+  const [text, setText] = useState(DEFAULT_TEXT)
+  const [preset, setPreset] = useState<Preset>('poetic')
+  const [settings, setSettings] = useState<Settings>(PRESETS.poetic)
+  const [seed, setSeed] = useState(Date.now())
+  const svgRef = useRef<SVGSVGElement | null>(null)
+  const composition = useMemo(() => generateComposition(text, seed, settings), [text, seed, settings])
+
+  const applyPreset = (next: Preset) => { setPreset(next); setSettings(PRESETS[next]) }
+  const goPlayground = (sample?: string) => { if (sample) setText(sample); setPage('playground'); setSeed(Date.now()) }
 
   const exportSvg = () => {
     if (!svgRef.current) return
-    const serializer = new XMLSerializer()
-    const svgText = serializer.serializeToString(svgRef.current)
-    const blob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = 'miro-type-poster.svg'
-    a.click()
-    URL.revokeObjectURL(url)
+    const blob = new Blob([new XMLSerializer().serializeToString(svgRef.current)], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'miro-type-poster.svg'; a.click(); URL.revokeObjectURL(url)
   }
 
-  const exportPng = async () => {
+  const exportPng = () => {
     if (!svgRef.current) return
-    const serializer = new XMLSerializer()
-    const svgText = serializer.serializeToString(svgRef.current)
-    const blob = new Blob([svgText], { type: 'image/svg+xml;charset=utf-8' })
-    const url = URL.createObjectURL(blob)
-    const img = new Image()
+    const svgBlob = new Blob([new XMLSerializer().serializeToString(svgRef.current)], { type: 'image/svg+xml;charset=utf-8' })
+    const url = URL.createObjectURL(svgBlob); const img = new Image()
     img.onload = () => {
-      const canvas = document.createElement('canvas')
-      canvas.width = CANVAS.width
-      canvas.height = CANVAS.height
-      const ctx = canvas.getContext('2d')
-      if (!ctx) return
+      const canvas = document.createElement('canvas'); canvas.width = CANVAS.width; canvas.height = CANVAS.height
+      const ctx = canvas.getContext('2d'); if (!ctx) return
       ctx.drawImage(img, 0, 0)
-      const png = canvas.toDataURL('image/png')
-      const a = document.createElement('a')
-      a.href = png
-      a.download = 'miro-type-poster.png'
-      a.click()
-      URL.revokeObjectURL(url)
+      const a = document.createElement('a'); a.href = canvas.toDataURL('image/png'); a.download = 'miro-type-poster.png'; a.click(); URL.revokeObjectURL(url)
     }
     img.src = url
   }
 
   return (
     <main className="app">
-      <section className="panel intro">
+      <header className="panel topbar">
         <h1>Miró Type Playground</h1>
-        <p>A playful experimental type system inspired by symbolic abstraction, hand-drawn lines, and poetic rhythm.</p>
-      </section>
-      <section className="workspace">
-        <aside className="panel controls">
-          <label>Text</label>
-          <input value={text} maxLength={MAX_TEXT_LENGTH} placeholder="Type a word or short phrase" onChange={(e) => setText(e.target.value)} />
+        <nav>{(['home', 'playground', 'glyphs', 'gallery', 'about'] as const).map((p) => <button key={p} className={page === p ? 'active' : ''} onClick={() => setPage(p)}>{p}</button>)}</nav>
+      </header>
 
-          <label>Preset</label>
-          <div className="preset-row">
-            {(['readable', 'poetic', 'wild'] as const).map((item) => (
-              <button key={item} className={preset === item ? 'active' : ''} onClick={() => applyPreset(item)}>{item}</button>
-            ))}
-          </div>
+      {page === 'home' && <section className="panel page"><h2>A playful experimental type system</h2><p>Inspired by symbolic abstraction, hand-drawn lines, and poetic visual rhythm.</p><div className="action-row"><button onClick={() => goPlayground()}>Start Creating</button><button onClick={() => setPage('glyphs')}>Explore Glyphs</button></div></section>}
 
-          {([
-            ['Abstractness', 'abstractness'],
-            ['Line Wobble', 'lineWobble'],
-            ['Symbol Density', 'symbolDensity'],
-            ['Color Intensity', 'colorIntensity'],
-          ] as const).map(([label, key]) => (
-            <div key={key} className="slider-group">
-              <div><span>{label}</span><strong>{settings[key]}</strong></div>
-              <input type="range" min={0} max={100} value={settings[key]} onChange={(e) => setSettings((prev) => ({ ...prev, [key]: Number(e.target.value) }))} />
-            </div>
-          ))}
+      {page === 'playground' && <section className="workspace"><aside className="panel controls"><label>Text</label><input value={text} maxLength={MAX_TEXT_LENGTH} placeholder="Type a word or short phrase" onChange={(e) => setText(e.target.value)} /><label>Preset</label><div className="preset-row">{(['readable', 'poetic', 'wild'] as const).map((item) => <button key={item} className={preset === item ? 'active' : ''} onClick={() => applyPreset(item)}>{item}</button>)}</div>{([['Abstractness', 'abstractness'], ['Line Wobble', 'lineWobble'], ['Symbol Density', 'symbolDensity'], ['Color Intensity', 'colorIntensity']] as const).map(([label, key]) => <div key={key} className="slider-group"><div><span>{label}</span><strong>{settings[key]}</strong></div><input type="range" min={0} max={100} value={settings[key]} onChange={(e) => setSettings((prev) => ({ ...prev, [key]: Number(e.target.value) }))} /></div>)}<div className="action-row"><button onClick={() => setSeed(Date.now())}>Regenerate</button><button onClick={exportPng}>Export PNG</button><button onClick={exportSvg}>Export SVG</button></div></aside><section className="panel canvas-wrap"><svg ref={svgRef} viewBox={`0 0 ${CANVAS.width} ${CANVAS.height}`}><rect width="100%" height="100%" fill={PALETTE.paper} />{composition.blobs.map((blob, i) => <ellipse key={i} cx={blob.cx} cy={blob.cy} rx={blob.rx} ry={blob.ry} fill={blob.color} opacity={blob.opacity} />)}{composition.lines.map((line, i) => <path key={i} d={line.path} stroke={line.color} strokeWidth={line.width} fill="none" strokeLinecap="round" strokeLinejoin="round" />)}{composition.symbols.map((sym, i) => <g key={i} transform={`translate(${sym.x} ${sym.y})`}>{sym.shape === 'dot' && <circle r={sym.size / 2} fill={sym.color} />}{sym.shape === 'eye' && <ellipse rx={sym.size * 0.6} ry={sym.size * 0.36} fill="none" stroke={sym.color} strokeWidth={3} />}{sym.shape === 'moon' && <path d={`M ${sym.size * 0.5} 0 A ${sym.size * 0.5} ${sym.size * 0.5} 0 1 1 ${-sym.size * 0.5} 0 A ${sym.size * 0.25} ${sym.size * 0.5} 0 1 0 ${sym.size * 0.5} 0`} fill={sym.color} />}{sym.shape === 'star' && <path d={`M 0 ${-sym.size} L ${sym.size * 0.25} ${-sym.size * 0.25} L ${sym.size} 0 L ${sym.size * 0.25} ${sym.size * 0.25} L 0 ${sym.size} L ${-sym.size * 0.25} ${sym.size * 0.25} L ${-sym.size} 0 L ${-sym.size * 0.25} ${-sym.size * 0.25} Z`} fill="none" stroke={sym.color} strokeWidth={2.2} />}</g>)}</svg></section></section>}
 
-          <div className="action-row">
-            <button onClick={() => setSeed(Date.now())}>Regenerate</button>
-            <button onClick={exportPng}>Export PNG</button>
-            <button onClick={exportSvg}>Export SVG</button>
-          </div>
-        </aside>
-
-        <section className="panel canvas-wrap">
-          <svg ref={svgRef} viewBox={`0 0 ${CANVAS.width} ${CANVAS.height}`}>
-            <rect width="100%" height="100%" fill={palette.paper} />
-            {composition.blobs.map((blob, i) => (
-              <ellipse key={`b-${i}`} cx={blob.cx} cy={blob.cy} rx={blob.rx} ry={blob.ry} fill={blob.color} opacity={blob.opacity} />
-            ))}
-            {composition.lines.map((line, i) => (
-              <path key={`l-${i}`} d={line.path} stroke={line.color} strokeWidth={line.width} fill="none" strokeLinecap="round" strokeLinejoin="round" />
-            ))}
-            {composition.symbols.map((sym, i) => (
-              <g key={`s-${i}`} transform={`translate(${sym.x} ${sym.y})`}>
-                {sym.shape === 'dot' && <circle r={sym.size / 2} fill={sym.color} />}
-                {sym.shape === 'eye' && <ellipse rx={sym.size * 0.6} ry={sym.size * 0.36} fill="none" stroke={sym.color} strokeWidth={3} />}
-                {sym.shape === 'moon' && <path d={`M ${sym.size * 0.5} 0 A ${sym.size * 0.5} ${sym.size * 0.5} 0 1 1 ${-sym.size * 0.5} 0 A ${sym.size * 0.25} ${sym.size * 0.5} 0 1 0 ${sym.size * 0.5} 0`} fill={sym.color} />}
-                {sym.shape === 'star' && <path d={`M 0 ${-sym.size} L ${sym.size * 0.25} ${-sym.size * 0.25} L ${sym.size} 0 L ${sym.size * 0.25} ${sym.size * 0.25} L 0 ${sym.size} L ${-sym.size * 0.25} ${sym.size * 0.25} L ${-sym.size} 0 L ${-sym.size * 0.25} ${-sym.size * 0.25} Z`} fill="none" stroke={sym.color} strokeWidth={2.2} />}
-              </g>
-            ))}
-          </svg>
-        </section>
-      </section>
+      {page === 'glyphs' && <section className="panel page"><h2>Glyph System</h2><p>Base Skeleton → Miró Line → Symbolic Composition</p><div className="glyph-grid">{glyphs.map((g) => <div key={g} className="glyph-cell">{g}</div>)}</div></section>}
+      {page === 'gallery' && <section className="panel page"><h2>Gallery</h2><div className="gallery-grid">{GALLERY_CASES.map((item) => <button key={item} onClick={() => goPlayground(item)}>{item}</button>)}</div></section>}
+      {page === 'about' && <section className="panel page"><h2>About</h2><p>This project is not an official Joan Miró typeface. It is an experimental type playground inspired by symbolic abstraction, childlike marks, poetic space, and primary-color composition.</p><p>这不是 Joan Miró 官方字体，也不是对其具体作品的复制。它是一套受其视觉语言启发的实验字体系统。</p></section>}
     </main>
   )
 }
-
-export default App

--- a/src/index.css
+++ b/src/index.css
@@ -1,92 +1,59 @@
 :root {
-  font-family: "Noto Serif SC", "Source Han Serif SC", serif;
-  color: #241f19;
-  background: #ece4d8;
+  font-family: Inter, system-ui, -apple-system, sans-serif;
+  color: #231d16;
+  background: #ece3d6;
 }
-
 * { box-sizing: border-box; }
 body { margin: 0; }
 
-.game {
+.app {
   min-height: 100vh;
-  padding: 0.75rem;
-  display: grid;
-  gap: 0.75rem;
+  padding: 1rem;
   background:
-    radial-gradient(circle at 20% 0%, rgba(255,255,255,0.5), transparent 45%),
-    linear-gradient(180deg, #efe6d7, #ded0ba);
+    radial-gradient(circle at 10% 0%, rgba(255,255,255,0.55), transparent 40%),
+    linear-gradient(180deg, #eee5d8, #e2d3bc);
+  display: grid;
+  gap: 1rem;
 }
 
 .panel {
-  background: rgba(253, 249, 241, 0.88);
-  border: 1px solid rgba(63, 51, 37, 0.3);
-  border-radius: 12px;
-  padding: 0.75rem;
-  box-shadow: 0 6px 16px rgba(55, 43, 28, 0.12);
+  background: rgba(253, 249, 240, 0.9);
+  border: 1px solid rgba(57, 44, 28, 0.25);
+  border-radius: 14px;
+  box-shadow: 0 8px 20px rgba(48, 37, 25, 0.1);
 }
 
-h1,h2,p { margin: 0; }
-h1 { font-size: 1.2rem; letter-spacing: 0.08em; }
-h2 { font-size: 1rem; margin-bottom: 0.4rem; }
+.intro { padding: 1rem; }
+.intro h1 { margin: 0 0 .45rem; font-size: 1.45rem; letter-spacing: .03em; }
+.intro p { margin: 0; line-height: 1.45; color: #4e4131; }
 
-.stats {
-  margin-top: 0.5rem;
-  display: flex;
-  justify-content: space-between;
-  font-size: 0.9rem;
-}
-
-.spirit p { color: #4d4337; font-size: 0.9rem; }
-
-.hand-grid {
-  margin-top: 0.5rem;
-  display: grid;
-  grid-template-columns: repeat(4, minmax(0, 1fr));
-  gap: 0.45rem;
-}
-
-.card {
-  border: 1px solid #5d4f3f;
-  background: linear-gradient(160deg, #fdf8ed, #eee0c8);
+.workspace { display: grid; gap: 1rem; }
+.controls { padding: 1rem; display: grid; gap: .7rem; align-content: start; }
+.controls label { font-weight: 600; font-size: .92rem; }
+input[type="text"], .controls input:not([type="range"]) {
+  border: 1px solid rgba(56, 45, 31, .35);
   border-radius: 10px;
-  min-height: 74px;
-  padding: 0.35rem;
-  text-align: left;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
+  padding: .6rem .7rem;
+  background: rgba(255,255,255,.9);
 }
-
-.card strong { font-size: 1.35rem; align-self: flex-end; }
-.card small { font-size: 0.72rem; color: #564b3f; }
-.card.active {
-  border-color: #1d1a14;
-  box-shadow: 0 0 0 2px rgba(44, 33, 22, 0.35) inset;
-}
-
-.actions p { font-size: 0.9rem; color: #4a4034; }
-.btn-row {
-  margin-top: 0.6rem;
-  display: grid;
-  gap: 0.5rem;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
-}
-
+.preset-row, .action-row { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: .5rem; }
 button {
   border: none;
-  border-radius: 8px;
-  background: #2b231a;
-  color: #f5eddd;
-  padding: 0.55rem 0.45rem;
+  border-radius: 10px;
+  padding: .55rem .6rem;
+  background: #2a231b;
+  color: #f4eddf;
+  cursor: pointer;
 }
+button.active { background: #1e5eff; }
+.slider-group { display: grid; gap: .35rem; }
+.slider-group div { display: flex; justify-content: space-between; font-size: .88rem; }
+input[type="range"] { width: 100%; }
 
-button:disabled { opacity: 0.5; }
-.result { margin-top: 0.6rem; color: #164e2b; }
-.result.fail { color: #7b1f1f; }
+.canvas-wrap { padding: .75rem; }
+svg { width: 100%; height: auto; border-radius: 10px; border: 1px solid rgba(17,17,17,.2); }
 
-@media (min-width: 768px) {
-  .game { max-width: 920px; margin: 0 auto; padding: 1.2rem; }
-  .panel { padding: 1rem; }
-  .hand-grid { grid-template-columns: repeat(8, minmax(0, 1fr)); }
-  h1 { font-size: 1.5rem; }
+@media (min-width: 980px) {
+  .app { padding: 1.2rem; max-width: 1320px; margin: 0 auto; }
+  .workspace { grid-template-columns: 350px 1fr; }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,27 +1,37 @@
 :root { font-family: Inter, system-ui, sans-serif; color: #231d16; background: #ece3d6; }
 * { box-sizing: border-box; }
 body { margin: 0; }
+
 .app { min-height: 100vh; padding: 1rem; background: radial-gradient(circle at 10% 0%, rgba(255,255,255,.55), transparent 40%), linear-gradient(180deg, #eee5d8, #e2d3bc); display: grid; gap: 1rem; }
 .panel { background: rgba(253, 249, 240, .9); border: 1px solid rgba(57,44,28,.25); border-radius: 14px; box-shadow: 0 8px 20px rgba(48,37,25,.1); }
 .topbar { padding: 1rem; display: flex; gap: .8rem; justify-content: space-between; align-items: center; flex-wrap: wrap; }
 .topbar h1 { margin: 0; font-size: 1.3rem; }
 .topbar nav { display: flex; gap: .45rem; flex-wrap: wrap; }
+
 .page { padding: 1rem; }
 .page h2 { margin: 0 0 .6rem; }
 .page p { margin: .4rem 0; line-height: 1.5; }
 .workspace { display: grid; gap: 1rem; }
 .controls { padding: 1rem; display: grid; gap: .7rem; align-content: start; }
 .controls label { font-weight: 600; font-size: .92rem; }
+.controls small { color: #5a4d3c; font-size: .8rem; }
+
 input[type="text"], .controls input:not([type="range"]) { border: 1px solid rgba(56,45,31,.35); border-radius: 10px; padding: .6rem .7rem; background: rgba(255,255,255,.9); }
 .preset-row, .action-row, .gallery-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: .5rem; }
+.home-actions { grid-template-columns: repeat(2, minmax(0, 220px)); }
 button { border: none; border-radius: 10px; padding: .55rem .6rem; background: #2a231b; color: #f4eddf; cursor: pointer; }
 button.active { background: #1e5eff; }
 .slider-group { display: grid; gap: .35rem; }
 .slider-group div { display: flex; justify-content: space-between; font-size: .88rem; }
 input[type="range"] { width: 100%; }
+
 .canvas-wrap { padding: .75rem; }
-svg { width: 100%; height: auto; border-radius: 10px; border: 1px solid rgba(17,17,17,.2); }
+svg { width: 100%; max-height: 78vh; border-radius: 10px; border: 1px solid rgba(17,17,17,.2); }
 .glyph-grid { margin-top: .8rem; display: grid; grid-template-columns: repeat(auto-fill,minmax(56px,1fr)); gap: .45rem; }
 .glyph-cell { padding: .65rem; border: 1px solid rgba(42,35,27,.25); border-radius: 8px; text-align: center; background: rgba(255,255,255,.7); }
 .gallery-grid { margin-top: .8rem; }
-@media (min-width: 980px) { .app { padding: 1.2rem; max-width: 1320px; margin: 0 auto; } .workspace { grid-template-columns: 350px 1fr; } }
+
+@media (min-width: 980px) {
+  .app { padding: 1.2rem; max-width: 1360px; margin: 0 auto; }
+  .workspace { grid-template-columns: 360px 1fr; }
+}

--- a/src/index.css
+++ b/src/index.css
@@ -1,59 +1,27 @@
-:root {
-  font-family: Inter, system-ui, -apple-system, sans-serif;
-  color: #231d16;
-  background: #ece3d6;
-}
+:root { font-family: Inter, system-ui, sans-serif; color: #231d16; background: #ece3d6; }
 * { box-sizing: border-box; }
 body { margin: 0; }
-
-.app {
-  min-height: 100vh;
-  padding: 1rem;
-  background:
-    radial-gradient(circle at 10% 0%, rgba(255,255,255,0.55), transparent 40%),
-    linear-gradient(180deg, #eee5d8, #e2d3bc);
-  display: grid;
-  gap: 1rem;
-}
-
-.panel {
-  background: rgba(253, 249, 240, 0.9);
-  border: 1px solid rgba(57, 44, 28, 0.25);
-  border-radius: 14px;
-  box-shadow: 0 8px 20px rgba(48, 37, 25, 0.1);
-}
-
-.intro { padding: 1rem; }
-.intro h1 { margin: 0 0 .45rem; font-size: 1.45rem; letter-spacing: .03em; }
-.intro p { margin: 0; line-height: 1.45; color: #4e4131; }
-
+.app { min-height: 100vh; padding: 1rem; background: radial-gradient(circle at 10% 0%, rgba(255,255,255,.55), transparent 40%), linear-gradient(180deg, #eee5d8, #e2d3bc); display: grid; gap: 1rem; }
+.panel { background: rgba(253, 249, 240, .9); border: 1px solid rgba(57,44,28,.25); border-radius: 14px; box-shadow: 0 8px 20px rgba(48,37,25,.1); }
+.topbar { padding: 1rem; display: flex; gap: .8rem; justify-content: space-between; align-items: center; flex-wrap: wrap; }
+.topbar h1 { margin: 0; font-size: 1.3rem; }
+.topbar nav { display: flex; gap: .45rem; flex-wrap: wrap; }
+.page { padding: 1rem; }
+.page h2 { margin: 0 0 .6rem; }
+.page p { margin: .4rem 0; line-height: 1.5; }
 .workspace { display: grid; gap: 1rem; }
 .controls { padding: 1rem; display: grid; gap: .7rem; align-content: start; }
 .controls label { font-weight: 600; font-size: .92rem; }
-input[type="text"], .controls input:not([type="range"]) {
-  border: 1px solid rgba(56, 45, 31, .35);
-  border-radius: 10px;
-  padding: .6rem .7rem;
-  background: rgba(255,255,255,.9);
-}
-.preset-row, .action-row { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: .5rem; }
-button {
-  border: none;
-  border-radius: 10px;
-  padding: .55rem .6rem;
-  background: #2a231b;
-  color: #f4eddf;
-  cursor: pointer;
-}
+input[type="text"], .controls input:not([type="range"]) { border: 1px solid rgba(56,45,31,.35); border-radius: 10px; padding: .6rem .7rem; background: rgba(255,255,255,.9); }
+.preset-row, .action-row, .gallery-grid { display: grid; grid-template-columns: repeat(3, minmax(0,1fr)); gap: .5rem; }
+button { border: none; border-radius: 10px; padding: .55rem .6rem; background: #2a231b; color: #f4eddf; cursor: pointer; }
 button.active { background: #1e5eff; }
 .slider-group { display: grid; gap: .35rem; }
 .slider-group div { display: flex; justify-content: space-between; font-size: .88rem; }
 input[type="range"] { width: 100%; }
-
 .canvas-wrap { padding: .75rem; }
 svg { width: 100%; height: auto; border-radius: 10px; border: 1px solid rgba(17,17,17,.2); }
-
-@media (min-width: 980px) {
-  .app { padding: 1.2rem; max-width: 1320px; margin: 0 auto; }
-  .workspace { grid-template-columns: 350px 1fr; }
-}
+.glyph-grid { margin-top: .8rem; display: grid; grid-template-columns: repeat(auto-fill,minmax(56px,1fr)); gap: .45rem; }
+.glyph-cell { padding: .65rem; border: 1px solid rgba(42,35,27,.25); border-radius: 8px; text-align: center; background: rgba(255,255,255,.7); }
+.gallery-grid { margin-top: .8rem; }
+@media (min-width: 980px) { .app { padding: 1.2rem; max-width: 1320px; margin: 0 auto; } .workspace { grid-template-columns: 350px 1fr; } }


### PR DESCRIPTION
### Motivation
- Implement the MVP described in `docs/miro-type-playground-mvp.md` by replacing the placeholder app with an interactive Miró-inspired poster generator.
- Provide a reproducible, client-side composition pipeline with simple controls so users can experiment with visual parameters and export results.

### Description
- Add a new interactive canvas in `src/App.tsx` that parses input text, maps characters to simple SVG skeletons, and composes disturbed strokes, symbols, and color blobs using a seeded PRNG (`hashSeed`, `createRand`, `jitter`).
- Expose three presets (`readable`, `poetic`, `wild`), four sliders (Abstractness, Line Wobble, Symbol Density, Color Intensity), text input (max 24 chars), and a `Regenerate` action that updates the seed.
- Implement client-side export functions `exportSvg` and `exportPng` that serialize the SVG and convert it to PNG using a canvas for direct download.
- Replace and redesign visual styles in `src/index.css` to a responsive control/canvas layout and poster-like look; no new dependencies were added.

### Testing
- Ran `npm run lint`, which completed without errors.
- Ran `npm run build`, which completed successfully and produced a working production bundle (build reported a Browserslist data warning but the build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f300ca2630832892ed114228bce661)