### PR TITLE
Add Prompt Gallery UI with mock data, copy tracking, and styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,10 @@
-import { useMemo, useState } from 'react'
-import { initialPrompts } from './mockData'
+import { useEffect, useMemo, useState } from 'react'
+import type { FormEvent } from 'react'
+import { hotTags, initialPrompts } from './mockData'
 import type { PromptItem, TabKey } from './types'
+
+const STORAGE_KEY = 'prompt-gallery-v1'
+const SEARCH_HISTORY_KEY = 'prompt-search-history-v1'
 
 function formatRelativeTime(value?: string): string {
   if (!value) return '刚刚'
@@ -12,11 +16,33 @@ function formatRelativeTime(value?: string): string {
   return `${Math.floor(diff / hour)} 小时前`
 }
 
+function safeJsonParse<T>(raw: string | null, fallback: T): T {
+  if (!raw) return fallback
+  try {
+    return JSON.parse(raw) as T
+  } catch {
+    return fallback
+  }
+}
+
 export default function App() {
   const [tab, setTab] = useState<TabKey>('gallery')
   const [query, setQuery] = useState('')
-  const [prompts, setPrompts] = useState<PromptItem[]>(initialPrompts)
-  const [selectedId, setSelectedId] = useState<string>(initialPrompts[0].id)
+  const [searchOpen, setSearchOpen] = useState(false)
+  const [prompts, setPrompts] = useState<PromptItem[]>(() => safeJsonParse(localStorage.getItem(STORAGE_KEY), initialPrompts))
+  const [searchHistory, setSearchHistory] = useState<string[]>(() =>
+    safeJsonParse(localStorage.getItem(SEARCH_HISTORY_KEY), [] as string[]),
+  )
+  const [selectedId, setSelectedId] = useState<string>(() => safeJsonParse(localStorage.getItem(STORAGE_KEY), initialPrompts)[0]?.id)
+  const [draft, setDraft] = useState({ imageUrl: '', title: '', prompt: '', tags: '', note: '' })
+
+  useEffect(() => {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(prompts))
+  }, [prompts])
+
+  useEffect(() => {
+    localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(searchHistory))
+  }, [searchHistory])
 
   const selected = prompts.find((item) => item.id === selectedId) ?? prompts[0]
 
@@ -29,10 +55,17 @@ export default function App() {
     })
   }, [prompts, query])
 
+  const favoriteList = useMemo(() => prompts.filter((item) => item.isFavorite), [prompts])
   const recent = useMemo(
     () => [...prompts].filter((item) => item.lastCopiedAt).sort((a, b) => (b.lastCopiedAt ?? '').localeCompare(a.lastCopiedAt ?? '')),
     [prompts],
   )
+
+  const registerSearch = (text: string) => {
+    const value = text.trim()
+    if (!value) return
+    setSearchHistory((prev) => [value, ...prev.filter((item) => item !== value)].slice(0, 8))
+  }
 
   const handleCopy = async (id: string) => {
     const item = prompts.find((prompt) => prompt.id === id)
@@ -56,22 +89,64 @@ export default function App() {
               ...entry,
               copyCount: entry.copyCount + 1,
               lastCopiedAt: new Date().toISOString(),
+              updatedAt: new Date().toISOString(),
             }
           : entry,
       ),
     )
   }
 
+  const toggleFavorite = (id: string) => {
+    setPrompts((prev) =>
+      prev.map((entry) =>
+        entry.id === id
+          ? {
+              ...entry,
+              isFavorite: !entry.isFavorite,
+              updatedAt: new Date().toISOString(),
+            }
+          : entry,
+      ),
+    )
+  }
+
+  const handleCreate = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    if (!draft.title.trim() || !draft.prompt.trim() || !draft.imageUrl.trim()) return
+
+    const item: PromptItem = {
+      id: crypto.randomUUID(),
+      title: draft.title.trim(),
+      prompt: draft.prompt.trim(),
+      imageUrl: draft.imageUrl.trim(),
+      tags: draft.tags.split(',').map((tag) => tag.trim()).filter(Boolean),
+      note: draft.note.trim() || undefined,
+      isFavorite: false,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+      copyCount: 0,
+    }
+
+    setPrompts((prev) => [item, ...prev])
+    setSelectedId(item.id)
+    setDraft({ imageUrl: '', title: '', prompt: '', tags: '', note: '' })
+    setTab('gallery')
+  }
+
   return (
     <main className="app-shell">
-      <header>
-        <h1>Prompt Gallery</h1>
-        <p>本地优先的 Prompt 与图片收藏库（MVP）</p>
+      <header className="header-row">
+        <div>
+          <h1>Prompt Gallery</h1>
+          <p>本地优先的 Prompt 与图片收藏库</p>
+        </div>
+        <button onClick={() => setSearchOpen(true)}>搜索浮层</button>
       </header>
 
       <section className="toolbar">
         <input
           value={query}
+          onFocus={() => setSearchOpen(true)}
           onChange={(event) => setQuery(event.target.value)}
           placeholder="搜索 prompt / 标签"
         />
@@ -81,11 +156,15 @@ export default function App() {
         <section className="layout">
           <div className="list-panel">
             {filtered.map((item) => (
-              <button key={item.id} className="card" onClick={() => setSelectedId(item.id)}>
-                <img src={item.imageUrl} alt={item.title} />
-                <strong>{item.title}</strong>
-                <span>{item.prompt.slice(0, 42)}...</span>
-              </button>
+              <article key={item.id} className="card-wrap">
+                <button className="card" onClick={() => setSelectedId(item.id)}>
+                  <img src={item.imageUrl} alt={item.title} />
+                  <strong>{item.title}</strong>
+                  <span>{item.prompt.slice(0, 42)}...</span>
+                </button>
+                <button className="mini" onClick={() => handleCopy(item.id)}>复制</button>
+                <button className="mini" onClick={() => toggleFavorite(item.id)}>{item.isFavorite ? '取消收藏' : '收藏'}</button>
+              </article>
             ))}
           </div>
 
@@ -93,20 +172,16 @@ export default function App() {
             <article className="detail-panel">
               <img src={selected.imageUrl} alt={selected.title} />
               <h2>{selected.title}</h2>
-              <div className="tags">
-                {selected.tags.map((tag) => (
-                  <em key={tag}>{tag}</em>
-                ))}
-              </div>
+              <div className="tags">{selected.tags.map((tag) => <em key={tag}>{tag}</em>)}</div>
               <p>{selected.prompt}</p>
               {selected.note && <small>备注：{selected.note}</small>}
-              <button className="copy-btn" onClick={() => handleCopy(selected.id)}>
-                复制 Prompt（已复制 {selected.copyCount} 次）
-              </button>
+              <button className="copy-btn" onClick={() => handleCopy(selected.id)}>复制 Prompt（已复制 {selected.copyCount} 次）</button>
             </article>
           )}
         </section>
       )}
+
+      {tab === 'favorites' && <section className="simple-list">{favoriteList.map((item) => <p key={item.id}>{item.title}</p>)}{favoriteList.length===0&&<p>暂无收藏</p>}</section>}
 
       {tab === 'recent' && (
         <section className="recent-panel">
@@ -126,14 +201,40 @@ export default function App() {
         </section>
       )}
 
-      {tab === 'favorites' && <section className="placeholder">收藏功能将在下一阶段实现。</section>}
-      {tab === 'settings' && <section className="placeholder">设置功能将在下一阶段实现。</section>}
+      {tab === 'settings' && (
+        <form className="create-form" onSubmit={handleCreate}>
+          <h3>新增流程（轻量）</h3>
+          <input placeholder="图片 URL" value={draft.imageUrl} onChange={(e) => setDraft((p) => ({ ...p, imageUrl: e.target.value }))} />
+          <input placeholder="标题" value={draft.title} onChange={(e) => setDraft((p) => ({ ...p, title: e.target.value }))} />
+          <textarea placeholder="Prompt" value={draft.prompt} onChange={(e) => setDraft((p) => ({ ...p, prompt: e.target.value }))} />
+          <input placeholder="标签（逗号分隔）" value={draft.tags} onChange={(e) => setDraft((p) => ({ ...p, tags: e.target.value }))} />
+          <textarea placeholder="备注（可选）" value={draft.note} onChange={(e) => setDraft((p) => ({ ...p, note: e.target.value }))} />
+          <button type="submit">保存到图库</button>
+        </form>
+      )}
+
+      {searchOpen && (
+        <aside className="overlay">
+          <div className="overlay-card">
+            <div className="overlay-head">
+              <strong>搜索浮层</strong>
+              <button onClick={() => setSearchOpen(false)}>关闭</button>
+            </div>
+            <div className="chips">{hotTags.map((tag) => <button key={tag} onClick={() => {setQuery(tag);registerSearch(tag)}}>{tag}</button>)}</div>
+            <div className="history">
+              <strong>搜索历史</strong>
+              {searchHistory.map((item) => <button key={item} onClick={() => {setQuery(item);registerSearch(item)}}>{item}</button>)}
+              {searchHistory.length > 0 && <button onClick={() => setSearchHistory([])}>清空</button>}
+            </div>
+          </div>
+        </aside>
+      )}
 
       <nav className="tabbar">
         <button onClick={() => setTab('gallery')} data-active={tab === 'gallery'}>图库</button>
         <button onClick={() => setTab('favorites')} data-active={tab === 'favorites'}>收藏</button>
         <button onClick={() => setTab('recent')} data-active={tab === 'recent'}>最近复制</button>
-        <button onClick={() => setTab('settings')} data-active={tab === 'settings'}>设置</button>
+        <button onClick={() => setTab('settings')} data-active={tab === 'settings'}>新增</button>
       </nav>
     </main>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,140 @@
+import { useMemo, useState } from 'react'
+import { initialPrompts } from './mockData'
+import type { PromptItem, TabKey } from './types'
+
+function formatRelativeTime(value?: string): string {
+  if (!value) return '刚刚'
+  const diff = Date.now() - new Date(value).getTime()
+  const minute = 60 * 1000
+  const hour = 60 * minute
+  if (diff < minute) return '刚刚'
+  if (diff < hour) return `${Math.floor(diff / minute)} 分钟前`
+  return `${Math.floor(diff / hour)} 小时前`
+}
+
 export default function App() {
+  const [tab, setTab] = useState<TabKey>('gallery')
+  const [query, setQuery] = useState('')
+  const [prompts, setPrompts] = useState<PromptItem[]>(initialPrompts)
+  const [selectedId, setSelectedId] = useState<string>(initialPrompts[0].id)
+
+  const selected = prompts.find((item) => item.id === selectedId) ?? prompts[0]
+
+  const filtered = useMemo(() => {
+    const normalized = query.toLowerCase().trim()
+    if (!normalized) return prompts
+    return prompts.filter((item) => {
+      const target = `${item.title} ${item.prompt} ${item.tags.join(' ')}`.toLowerCase()
+      return target.includes(normalized)
+    })
+  }, [prompts, query])
+
+  const recent = useMemo(
+    () => [...prompts].filter((item) => item.lastCopiedAt).sort((a, b) => (b.lastCopiedAt ?? '').localeCompare(a.lastCopiedAt ?? '')),
+    [prompts],
+  )
+
+  const handleCopy = async (id: string) => {
+    const item = prompts.find((prompt) => prompt.id === id)
+    if (!item) return
+
+    try {
+      await navigator.clipboard.writeText(item.prompt)
+    } catch {
+      const textArea = document.createElement('textarea')
+      textArea.value = item.prompt
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+    }
+
+    setPrompts((prev) =>
+      prev.map((entry) =>
+        entry.id === id
+          ? {
+              ...entry,
+              copyCount: entry.copyCount + 1,
+              lastCopiedAt: new Date().toISOString(),
+            }
+          : entry,
+      ),
+    )
+  }
+
   return (
-    <main className="minimal-page">
-      <section className="minimal-card">
-        <h1>Typing Master</h1>
-        <p>Less noise. More focus.</p>
+    <main className="app-shell">
+      <header>
+        <h1>Prompt Gallery</h1>
+        <p>本地优先的 Prompt 与图片收藏库（MVP）</p>
+      </header>
+
+      <section className="toolbar">
+        <input
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="搜索 prompt / 标签"
+        />
       </section>
+
+      {tab === 'gallery' && (
+        <section className="layout">
+          <div className="list-panel">
+            {filtered.map((item) => (
+              <button key={item.id} className="card" onClick={() => setSelectedId(item.id)}>
+                <img src={item.imageUrl} alt={item.title} />
+                <strong>{item.title}</strong>
+                <span>{item.prompt.slice(0, 42)}...</span>
+              </button>
+            ))}
+          </div>
+
+          {selected && (
+            <article className="detail-panel">
+              <img src={selected.imageUrl} alt={selected.title} />
+              <h2>{selected.title}</h2>
+              <div className="tags">
+                {selected.tags.map((tag) => (
+                  <em key={tag}>{tag}</em>
+                ))}
+              </div>
+              <p>{selected.prompt}</p>
+              {selected.note && <small>备注：{selected.note}</small>}
+              <button className="copy-btn" onClick={() => handleCopy(selected.id)}>
+                复制 Prompt（已复制 {selected.copyCount} 次）
+              </button>
+            </article>
+          )}
+        </section>
+      )}
+
+      {tab === 'recent' && (
+        <section className="recent-panel">
+          {recent.length === 0 && <p>暂无复制记录</p>}
+          {recent.map((item) => (
+            <div className="recent-item" key={item.id}>
+              <div>
+                <strong>{item.title}</strong>
+                <p>{item.prompt.slice(0, 80)}...</p>
+              </div>
+              <div>
+                <span>{formatRelativeTime(item.lastCopiedAt)}</span>
+                <button onClick={() => handleCopy(item.id)}>再次复制</button>
+              </div>
+            </div>
+          ))}
+        </section>
+      )}
+
+      {tab === 'favorites' && <section className="placeholder">收藏功能将在下一阶段实现。</section>}
+      {tab === 'settings' && <section className="placeholder">设置功能将在下一阶段实现。</section>}
+
+      <nav className="tabbar">
+        <button onClick={() => setTab('gallery')} data-active={tab === 'gallery'}>图库</button>
+        <button onClick={() => setTab('favorites')} data-active={tab === 'favorites'}>收藏</button>
+        <button onClick={() => setTab('recent')} data-active={tab === 'recent'}>最近复制</button>
+        <button onClick={() => setTab('settings')} data-active={tab === 'settings'}>设置</button>
+      </nav>
     </main>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,48 +1,118 @@
 :root {
-  color-scheme: light;
-  font-family: "Inter", "Helvetica Neue", Arial, sans-serif;
-  background: #ffffff;
-  color: #111111;
+  font-family: Inter, system-ui, sans-serif;
+  color: #111827;
+  background: #f3f4f6;
 }
 
-* {
-  box-sizing: border-box;
+* { box-sizing: border-box; }
+body { margin: 0; }
+
+.app-shell {
+  max-width: 1180px;
+  margin: 0 auto;
+  padding: 20px;
 }
 
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: #ffffff;
-  color: #111111;
+.toolbar input {
+  width: 100%;
+  border: 1px solid #d1d5db;
+  border-radius: 12px;
+  padding: 12px;
 }
 
-#root {
-  min-height: 100vh;
-}
-
-.minimal-page {
-  min-height: 100vh;
+.layout {
+  margin-top: 16px;
   display: grid;
-  place-items: center;
-  padding: 24px;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
 }
 
-.minimal-card {
-  border: 1px solid #111111;
-  padding: 32px 36px;
-  text-align: center;
-  max-width: 520px;
+.list-panel {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
 }
 
-.minimal-card h1 {
-  margin: 0 0 12px;
-  font-size: clamp(2rem, 8vw, 3.5rem);
-  letter-spacing: 0.08em;
-  text-transform: uppercase;
+.card {
+  text-align: left;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  background: white;
+  padding: 8px;
 }
 
-.minimal-card p {
-  margin: 0;
-  font-size: 1rem;
-  letter-spacing: 0.04em;
+.card img, .detail-panel img {
+  width: 100%;
+  border-radius: 10px;
+  aspect-ratio: 4/3;
+  object-fit: cover;
+}
+
+.card strong { display: block; margin-top: 8px; }
+.card span { color: #6b7280; font-size: 14px; }
+
+.detail-panel {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 14px;
+}
+
+.tags { display: flex; gap: 8px; flex-wrap: wrap; }
+.tags em { font-style: normal; background: #f3f4f6; padding: 4px 10px; border-radius: 999px; }
+
+.copy-btn {
+  width: 100%;
+  margin-top: 12px;
+  border: 0;
+  background: #111827;
+  color: white;
+  padding: 12px;
+  border-radius: 12px;
+}
+
+.recent-item {
+  background: white;
+  border: 1px solid #e5e7eb;
+  border-radius: 12px;
+  padding: 12px;
+  margin-top: 12px;
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tabbar {
+  position: sticky;
+  bottom: 0;
+  margin-top: 24px;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+  background: #f3f4f6;
+  padding-top: 8px;
+}
+
+.tabbar button {
+  border: 1px solid #d1d5db;
+  padding: 10px;
+  border-radius: 10px;
+  background: white;
+}
+
+.tabbar button[data-active='true'] {
+  background: #111827;
+  color: white;
+}
+
+.placeholder {
+  margin-top: 20px;
+  padding: 30px;
+  background: white;
+  border: 1px dashed #d1d5db;
+  border-radius: 12px;
+}
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,118 +1,25 @@
-:root {
-  font-family: Inter, system-ui, sans-serif;
-  color: #111827;
-  background: #f3f4f6;
-}
-
+:root { font-family: Inter, system-ui, sans-serif; color: #111827; background: #f3f4f6; }
 * { box-sizing: border-box; }
 body { margin: 0; }
-
-.app-shell {
-  max-width: 1180px;
-  margin: 0 auto;
-  padding: 20px;
-}
-
-.toolbar input {
-  width: 100%;
-  border: 1px solid #d1d5db;
-  border-radius: 12px;
-  padding: 12px;
-}
-
-.layout {
-  margin-top: 16px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 16px;
-}
-
-.list-panel {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 10px;
-}
-
-.card {
-  text-align: left;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  background: white;
-  padding: 8px;
-}
-
-.card img, .detail-panel img {
-  width: 100%;
-  border-radius: 10px;
-  aspect-ratio: 4/3;
-  object-fit: cover;
-}
-
-.card strong { display: block; margin-top: 8px; }
-.card span { color: #6b7280; font-size: 14px; }
-
-.detail-panel {
-  background: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 14px;
-}
-
-.tags { display: flex; gap: 8px; flex-wrap: wrap; }
-.tags em { font-style: normal; background: #f3f4f6; padding: 4px 10px; border-radius: 999px; }
-
-.copy-btn {
-  width: 100%;
-  margin-top: 12px;
-  border: 0;
-  background: #111827;
-  color: white;
-  padding: 12px;
-  border-radius: 12px;
-}
-
-.recent-item {
-  background: white;
-  border: 1px solid #e5e7eb;
-  border-radius: 12px;
-  padding: 12px;
-  margin-top: 12px;
-  display: flex;
-  justify-content: space-between;
-  gap: 12px;
-}
-
-.tabbar {
-  position: sticky;
-  bottom: 0;
-  margin-top: 24px;
-  display: grid;
-  grid-template-columns: repeat(4, 1fr);
-  gap: 8px;
-  background: #f3f4f6;
-  padding-top: 8px;
-}
-
-.tabbar button {
-  border: 1px solid #d1d5db;
-  padding: 10px;
-  border-radius: 10px;
-  background: white;
-}
-
-.tabbar button[data-active='true'] {
-  background: #111827;
-  color: white;
-}
-
-.placeholder {
-  margin-top: 20px;
-  padding: 30px;
-  background: white;
-  border: 1px dashed #d1d5db;
-  border-radius: 12px;
-}
-
-@media (max-width: 900px) {
-  .layout { grid-template-columns: 1fr; }
-}
+.app-shell { max-width: 1180px; margin: 0 auto; padding: 20px; }
+.header-row{display:flex;justify-content:space-between;align-items:center;gap:12px}
+.toolbar input, .create-form input, .create-form textarea { width: 100%; border: 1px solid #d1d5db; border-radius: 12px; padding: 12px; margin-top:10px }
+.layout { margin-top: 16px; display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+.list-panel { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; }
+.card-wrap{background:#fff;border:1px solid #e5e7eb;border-radius:12px;padding:8px}
+.card { text-align: left; border: 0; background: white; padding: 0; width:100%; }
+.card img, .detail-panel img { width: 100%; border-radius: 10px; aspect-ratio: 4/3; object-fit: cover; }
+.card strong { display: block; margin-top: 8px; } .card span { color: #6b7280; font-size: 14px; }
+.mini{margin-right:6px;margin-top:8px;border:1px solid #d1d5db;background:#fff;border-radius:8px;padding:4px 8px}
+.detail-panel, .recent-item, .create-form, .simple-list { background: white; border: 1px solid #e5e7eb; border-radius: 12px; padding: 14px; }
+.tags { display: flex; gap: 8px; flex-wrap: wrap; } .tags em { font-style: normal; background: #f3f4f6; padding: 4px 10px; border-radius: 999px; }
+.copy-btn { width: 100%; margin-top: 12px; border: 0; background: #111827; color: white; padding: 12px; border-radius: 12px; }
+.recent-item { margin-top: 12px; display: flex; justify-content: space-between; gap: 12px; }
+.overlay{position:fixed;inset:0;background:rgba(0,0,0,.3);display:grid;place-items:center;padding:16px}
+.overlay-card{width:min(700px,100%);background:#fff;padding:16px;border-radius:12px}
+.overlay-head{display:flex;justify-content:space-between;align-items:center}
+.chips,.history{display:flex;gap:8px;flex-wrap:wrap;margin-top:10px}
+.chips button,.history button,.header-row button,.tabbar button,.recent-item button,.create-form button{border:1px solid #d1d5db;background:#fff;border-radius:10px;padding:8px 10px}
+.tabbar { position: sticky; bottom: 0; margin-top: 24px; display: grid; grid-template-columns: repeat(4, 1fr); gap: 8px; background: #f3f4f6; padding-top: 8px; }
+.tabbar button[data-active='true'] { background: #111827; color: white; }
+@media (max-width: 900px) { .layout { grid-template-columns: 1fr; } }

--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -1,5 +1,7 @@
 import type { PromptItem } from './types'
 
+const now = new Date().toISOString()
+
 export const initialPrompts: PromptItem[] = [
   {
     id: 'mountain-lake',
@@ -9,6 +11,9 @@ export const initialPrompts: PromptItem[] = [
     tags: ['自然', '风景', '湖泊'],
     note: '参考了瑞士阿尔卑斯山的景色。',
     imageUrl: 'https://images.unsplash.com/photo-1464822759844-d150ad6d13e5?auto=format&fit=crop&w=1200&q=80',
+    isFavorite: true,
+    createdAt: now,
+    updatedAt: now,
     copyCount: 0,
   },
   {
@@ -18,6 +23,9 @@ export const initialPrompts: PromptItem[] = [
       'An astronaut standing on the surface of an alien planet, with distant planets in the sky, cinematic lighting, high contrast, epic composition.',
     tags: ['科幻', '人物'],
     imageUrl: 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?auto=format&fit=crop&w=1200&q=80',
+    isFavorite: false,
+    createdAt: now,
+    updatedAt: now,
     copyCount: 0,
   },
   {
@@ -27,6 +35,11 @@ export const initialPrompts: PromptItem[] = [
       'Anime style girl standing in the rain, city lights background, melancholic mood, wet hair details, dramatic rim light.',
     tags: ['插画', '人物'],
     imageUrl: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80',
+    isFavorite: false,
+    createdAt: now,
+    updatedAt: now,
     copyCount: 0,
   },
 ]
+
+export const hotTags = ['风景', '建筑', '人物', '科幻', '插画', '室内']

--- a/src/mockData.ts
+++ b/src/mockData.ts
@@ -1,0 +1,32 @@
+import type { PromptItem } from './types'
+
+export const initialPrompts: PromptItem[] = [
+  {
+    id: 'mountain-lake',
+    title: '宁静的山间湖泊',
+    prompt:
+      'A serene mountain lake surrounded by pine trees and rocky peaks, crystal clear water reflecting the sky and mountains, soft natural sunlight, photorealistic, ultra detailed, 8k.',
+    tags: ['自然', '风景', '湖泊'],
+    note: '参考了瑞士阿尔卑斯山的景色。',
+    imageUrl: 'https://images.unsplash.com/photo-1464822759844-d150ad6d13e5?auto=format&fit=crop&w=1200&q=80',
+    copyCount: 0,
+  },
+  {
+    id: 'astronaut',
+    title: '宇航员在陌生星球',
+    prompt:
+      'An astronaut standing on the surface of an alien planet, with distant planets in the sky, cinematic lighting, high contrast, epic composition.',
+    tags: ['科幻', '人物'],
+    imageUrl: 'https://images.unsplash.com/photo-1446776877081-d282a0f896e2?auto=format&fit=crop&w=1200&q=80',
+    copyCount: 0,
+  },
+  {
+    id: 'rain-girl',
+    title: '雨中的少女',
+    prompt:
+      'Anime style girl standing in the rain, city lights background, melancholic mood, wet hair details, dramatic rim light.',
+    tags: ['插画', '人物'],
+    imageUrl: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=1200&q=80',
+    copyCount: 0,
+  },
+]

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,6 +5,9 @@ export type PromptItem = {
   tags: string[]
   note?: string
   imageUrl: string
+  isFavorite: boolean
+  createdAt: string
+  updatedAt: string
   lastCopiedAt?: string
   copyCount: number
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+export type PromptItem = {
+  id: string
+  title: string
+  prompt: string
+  tags: string[]
+  note?: string
+  imageUrl: string
+  lastCopiedAt?: string
+  copyCount: number
+}
+
+export type TabKey = 'gallery' | 'favorites' | 'recent' | 'settings'


### PR DESCRIPTION
### Motivation
- Introduce a simple local-first prompt gallery MVP to browse, search, view details, and copy prompts with basic usage tracking.
- Provide typed data structures and bundled mock data to enable a predictable demo state for development and testing.

### Description
- Replace the previous minimal page with a new `App` UI that implements tabbed views (`gallery`, `favorites`, `recent`, `settings`), search, list/detail panels, and a copy action that updates `copyCount` and `lastCopiedAt`.
- Add `formatRelativeTime` helper and a `recent` view that sorts and displays recently copied prompts and allows re-copying from the list.
- Add typed domain models in `src/types.ts` and initial in-memory mock prompts in `src/mockData.ts` used to seed the app state.
- Overhaul styles in `src/index.css` to provide layout, card, detail, responsive grid, tab bar and component styling for the new gallery UI.

### Testing
- Performed TypeScript type checking with `tsc --noEmit`, which completed successfully.
- No unit tests were added in this change-set and there are no existing automated UI tests exercised by this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6f2e466f88328bf2399e4dae706e2)