### PR TITLE
feat: 汉字笔顺演示 - 手机适配 + 主页入口

### DIFF
--- a/public/tutorials/index.html
+++ b/public/tutorials/index.html
@@ -29,6 +29,7 @@ h1 span{color:#7c8aff}
 .card:nth-child(1)::before{background:#d97757}
 .card:nth-child(2)::before{background:#68d391}
 .card:nth-child(3)::before{background:#7c8aff}
+.card:nth-child(4)::before{background:#fb923c}
 .card .icon{font-size:36px;margin-bottom:12px}
 .card h2{font-size:18px;font-weight:600;margin-bottom:6px}
 .card p{font-size:13px;color:#9498a8;flex:1;margin-bottom:12px}
@@ -39,6 +40,7 @@ h1 span{color:#7c8aff}
 .card:nth-child(1) .tag{background:rgba(217,119,87,0.12);color:#d97757}
 .card:nth-child(2) .tag{background:rgba(104,211,145,0.12);color:#68d391}
 .card:nth-child(3) .tag{background:rgba(124,138,255,0.12);color:#7c8aff}
+.card:nth-child(4) .tag{background:rgba(251,146,60,0.12);color:#fb923c}
 .back-to{text-align:center;margin-top:16px}
 .back-to a{color:#5c6070;font-size:13px;text-decoration:none;transition:.2s}
 .back-to a:hover{color:#9498a8}
@@ -69,6 +71,13 @@ h1 span{color:#7c8aff}
       <h2>Three.js 3D 教程</h2>
       <p>WebGL 的优雅抽象层：场景三件套、几何体、材质与光照、动画循环、OrbitControls 交互。</p>
       <span class="tag">3D · WebGL</span>
+    </a>
+
+    <a href="jingyesi.html" class="card">
+      <div class="icon">🖌</div>
+      <h2>汉字笔顺演示</h2>
+      <p>交互式逐笔动画。输入任意汉字，实时查看笔顺，支持播放、暂停、前后切换。</p>
+      <span class="tag">汉字 · HanziWriter</span>
     </a>
   </div>
 

--- a/public/tutorials/jingyesi.html
+++ b/public/tutorials/jingyesi.html
@@ -233,26 +233,27 @@ body{
 
 /* ── Mobile responsive ── */
 @media(max-width:640px){
-  body{flex-direction:column}
+  body{flex-direction:column;height:auto;min-height:100vh}
   .sidebar{
     width:100%;min-width:0;
-    padding:16px;border-right:none;
+    padding:14px 16px;border-right:none;
     border-bottom:1px solid var(--border);
-    gap:2px;
+    gap:0;
   }
-  .sidebar-brand{margin-bottom:16px;font-size:18px}
+  .sidebar-brand{margin-bottom:12px;font-size:17px}
+  .input-group{margin-bottom:12px}
   .input-group textarea{font-size:14px;padding:8px 10px}
-  .chips{margin-bottom:12px;gap:3px}
-  .chips-label{margin-bottom:4px}
-  .char-meta{margin-bottom:10px;padding-top:8px}
-  .controls{margin-top:8px;padding-top:8px}
-  .controls button{padding:6px 0;font-size:12px}
-  .main{padding:20px}
-  .canvas-wrap{width:180px;height:180px}
-  .canvas-wrap .target svg{width:160px;height:160px}
+  .chips-label,.chips{margin-bottom:10px}
+  .chips{gap:3px}
+  .char-meta{margin-bottom:8px;padding-top:8px}
+  .controls{margin-top:4px;padding-top:8px}
+  .controls button{padding:8px 0;font-size:12px}
+  .main{padding:24px 16px;min-height:50vh}
+  .canvas-wrap{width:170px;height:170px}
+  .canvas-wrap .target svg{width:155px;height:155px}
   .canvas-wrap .glow-ring{inset:-8px}
-  .char-label{font-size:28px}
-  .progress{font-size:10px}
+  .char-label{font-size:24px}
+  .progress{font-size:10px;margin-top:10px}
   .kbd-hint{display:none}
 }
 </style>
@@ -276,7 +277,7 @@ body{
   </div>
 
   <div class="controls">
-    <button id="prevBtn" title">◀</button>
+    <button id="prevBtn">◀</button>
     <button class="play" id="playBtn">▶</button>
     <button id="nextBtn">▶</button>
   </div>

--- a/public/tutorials/jingyesi.html
+++ b/public/tutorials/jingyesi.html
@@ -230,6 +230,31 @@ body{
   font-family:var(--font-ui);
   font-size:9px;color:var(--ink-muted);
 }
+
+/* ── Mobile responsive ── */
+@media(max-width:640px){
+  body{flex-direction:column}
+  .sidebar{
+    width:100%;min-width:0;
+    padding:16px;border-right:none;
+    border-bottom:1px solid var(--border);
+    gap:2px;
+  }
+  .sidebar-brand{margin-bottom:16px;font-size:18px}
+  .input-group textarea{font-size:14px;padding:8px 10px}
+  .chips{margin-bottom:12px;gap:3px}
+  .chips-label{margin-bottom:4px}
+  .char-meta{margin-bottom:10px;padding-top:8px}
+  .controls{margin-top:8px;padding-top:8px}
+  .controls button{padding:6px 0;font-size:12px}
+  .main{padding:20px}
+  .canvas-wrap{width:180px;height:180px}
+  .canvas-wrap .target svg{width:160px;height:160px}
+  .canvas-wrap .glow-ring{inset:-8px}
+  .char-label{font-size:28px}
+  .progress{font-size:10px}
+  .kbd-hint{display:none}
+}
 </style>
 </head>
 <body>

--- a/public/tutorials/jingyesi.html
+++ b/public/tutorials/jingyesi.html
@@ -249,9 +249,8 @@ body{
   .controls{margin-top:4px;padding-top:8px}
   .controls button{padding:8px 0;font-size:12px}
   .main{padding:24px 16px;min-height:50vh}
-  .canvas-wrap{width:170px;height:170px}
-  .canvas-wrap .target svg{width:155px;height:155px}
-  .canvas-wrap .glow-ring{inset:-8px}
+  .canvas-wrap{width:220px;height:220px}
+  .canvas-wrap .glow-ring{inset:-12px}
   .char-label{font-size:24px}
   .progress{font-size:10px;margin-top:10px}
   .kbd-hint{display:none}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,7 @@ const categories = [
       { id: 'pi', label: 'π Agent', href: '/tutorials/pi-agent-tutorial.html', icon: 'π', color: '#d97757', desc: '终端编码代理入门' },
       { id: 'gsap', label: 'GSAP', href: '/tutorials/gsap-tutorial.html', icon: '⚡', color: '#68d391', desc: '前端动画库核心概念' },
       { id: 'threejs', label: 'Three.js', href: '/tutorials/threejs-tutorial.html', icon: '🎲', color: '#7c8aff', desc: 'WebGL 3D 场景构建' },
+      { id: 'hanzi', label: '汉字笔顺', href: '/tutorials/jingyesi.html', icon: '🖌', color: '#fb923c', desc: '交互式汉字笔画逐笔动画' },
     ]
   },
   {
@@ -21,7 +22,8 @@ const featured = [
   { id: 'pi', title: 'π Agent', desc: '7 个原语工具，无限可能。从 LLM 到 Agent 的跃迁。', icon: 'π', color: '#d97757', bg: 'rgba(217,119,87,0.08)', href: '/tutorials/pi-agent-tutorial.html' },
   { id: 'gsap', title: 'GSAP 动画', desc: 'Tween、缓动、时间线编排、Stagger、ScrollTrigger。', icon: '⚡', color: '#68d391', bg: 'rgba(104,211,145,0.08)', href: '/tutorials/gsap-tutorial.html' },
   { id: 'threejs', title: 'Three.js 3D', desc: '场景三件套、几何体、材质光照、动画循环。', icon: '🎲', color: '#7c8aff', bg: 'rgba(124,138,255,0.08)', href: '/tutorials/threejs-tutorial.html' },
-]
+  { id: 'hanzi', title: '汉字笔顺', desc: 'HanziWriter 交互式逐笔动画。', icon: '🖌', color: '#fb923c', bg: 'rgba(251,146,60,0.08)', href: '/tutorials/jingyesi.html' },
+  ]
 
 export default function App() {
   const [activeId, setActiveId] = useState('pi')


### PR DESCRIPTION
### 更新内容

**1. 手机浏览器适配** (`public/tutorials/jingyesi.html`)
- 屏幕 < 640px 时侧栏变为顶部，主区自动下移
- 画布缩小至 180×180，间距压缩
- 键盘提示在手机上隐藏

**2. 主页添加入口** (`src/App.tsx`)
- 左侧导航栏新增「汉字笔顺」链接
- 精选区新增汉字笔顺卡片（橙色 `#fb923c`）

**3. 教程页添加卡片** (`public/tutorials/index.html`)
- 第 4 张卡片，橙色主题色